### PR TITLE
Added manual installation instructions in README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+
+# Created by https://www.gitignore.io/api/vim,visualstudiocode
+# Edit at https://www.gitignore.io/?templates=vim,visualstudiocode
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+# End of https://www.gitignore.io/api/vim,visualstudiocode

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# gnome-shell-extension-kubeconfig
-Gnome-shell extension for switching kube config context
+# gnome-shell-extension kubeconfig
+Gnome shell extension for switching Kubernetes cli: `kubectl` config context.
+
+## Manual Installation
+
+See [this guide](https://itsfoss.com/gnome-shell-extensions/) for inspiration.
+Tested working on Ubuntu 18.04.3 LTS with Gnome 2.28.2
+
+```bash
+# just copy and paste this into your terminal line by line
+# essentially just clone into your extension directory and then
+# modify manifest.js to match the original fork's uuid of the extension
+
+cd ~/.local/share/gnome-shell/extensions
+git clone git@github.com:anthonyrichir/gnome-shell-extension-kubeconfig.git
+mv gnome-shell-extension-kubeconfig kube_config@vvbogdanov87.gmail.com
+```
+
+Now restart GNOME Shell. Press `Alt+F2` and enter `r` to restart GNOME Shell, for [debugging](https://stackoverflow.com/questions/8425616/how-to-test-debug-gnome-shell-extensions-is-there-any-tool-for-that) Press `Alt+F2` and enter `lg`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See [this guide](https://itsfoss.com/gnome-shell-extensions/) for inspiration.
 Tested working on Ubuntu 18.04.3 LTS with Gnome 2.28.2
 
 ```bash
-# just copy and paste this into your terminal line by line
+# tl;dr just copy and paste this into your terminal
 # essentially just clone into your extension directory and then
 # modify manifest.js to match the original fork's uuid of the extension
 


### PR DESCRIPTION
Needed clear instructions for installing this fork in the CLI as on the gnome plugin store the original doesn't work anymore
- added `.gitignore`
- added copy+paste instructions in `README.md`